### PR TITLE
Flush output buffer before run readfile

### DIFF
--- a/modules/servers/namecheapssl/namecheapssl.php
+++ b/modules/servers/namecheapssl/namecheapssl.php
@@ -2720,6 +2720,8 @@ function namecheapssl_download($params){
         header('Content-Type: application/zip');
         header('Content-Length: ' . filesize($temp_file));
         header('Content-Disposition: attachment; filename="' . str_replace('.','_',$commonName) . '.zip"');
+        ob_clean();
+        flush();
         readfile($temp_file);
         unlink($temp_file);
         exit();


### PR DESCRIPTION
Fix issue regarding additional whitespaces in saved zip files, which result to
broken archives. Whitespaces looks like are generated by WHMCS, issue started
to appear on WHMCS 7.6.0.