### PR TITLE
Fix SSL order creation

### DIFF
--- a/modules/servers/namecheapssl/namecheapssl.php
+++ b/modules/servers/namecheapssl/namecheapssl.php
@@ -622,6 +622,8 @@ function namecheapssl_CreateAccount($params) {
         "remoteid" => $certificateId,
         "module" => "namecheapssl",
         "certtype" => $certtype,
+        "provisiondate" => "0000-00-00",
+        "configdata" => "",
         "status" => _namecheapssl_getIncompleteStatus()
     );
     $sslorderid = NcSql::insert('tblsslorders',$queryData);


### PR DESCRIPTION
Although I know this module is no longer under supported, perhaps this might help anybody else having trouble with it under WHMCS 7.9.x.